### PR TITLE
chore: add mit license to or-guard package

### DIFF
--- a/packages/or-guard/package.json
+++ b/packages/or-guard/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@nest-lab/or-guard",
+  "license": "MIT",
   "description": "A mixin guard that allows for one of N guards to pass for the request to be considers authenticated.",
   "author": {
     "name": "Jay McDoniel",


### PR DESCRIPTION
Noticed there's MIT license in other packages apart from this one.