### PR TITLE
fix: allow for multiple register async calls

### DIFF
--- a/.changeset/chatty-dolls-pull.md
+++ b/.changeset/chatty-dolls-pull.md
@@ -1,0 +1,7 @@
+---
+'@nest-lab/fastify-multer': patch
+---
+
+allow for multiple `registerAsync` calls
+
+By moving the registration of the multipart content parse to a separate core module, the core module only gets activated once which allows for multiple `registerAsync` calls without calling the `fastify.register()` multiple times. This should resovle the error in #11.

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 /out-tsc
 
 # dependencies
-/node_modules
+**/node_modules
 
 # IDEs and editors
 /.idea
@@ -16,6 +16,7 @@
 *.launch
 .settings/
 *.sublime-workspace
+tags
 
 # IDE - VSCode
 .vscode/*

--- a/packages/fastify-multer/node_modules/fastify-multer
+++ b/packages/fastify-multer/node_modules/fastify-multer
@@ -1,1 +1,0 @@
-../../../node_modules/.pnpm/fastify-multer@2.0.3/node_modules/fastify-multer

--- a/packages/fastify-multer/project.json
+++ b/packages/fastify-multer/project.json
@@ -39,7 +39,12 @@
     "test": {
       "executor": "@nrwl/workspace:run-commands",
       "options": {
-        "command": "node -r @swc/register --test packages/fastify-multer/test/file-upload.spec.ts"
+        "command": "node -r @swc/register --test packages/fastify-multer/test/index.spec.ts"
+      },
+      "configurations": {
+        "local": {
+          "command": "node -r @swc/register packages/fastify-multer/test/index.spec.ts"
+        }
       }
     }
   },

--- a/packages/fastify-multer/src/lib/fastify-multer-core.module.ts
+++ b/packages/fastify-multer/src/lib/fastify-multer-core.module.ts
@@ -1,0 +1,17 @@
+import { Module, OnApplicationBootstrap } from '@nestjs/common';
+import { HttpAdapterHost } from '@nestjs/core';
+import { FastifyAdapter } from '@nestjs/platform-fastify';
+import multer from 'fastify-multer';
+
+@Module({})
+export class FastifyCoreModule implements OnApplicationBootstrap {
+  constructor(
+    private readonly httpAdapterHost: HttpAdapterHost<FastifyAdapter>
+  ) {}
+  onApplicationBootstrap() {
+    const fastify = this.httpAdapterHost.httpAdapter.getInstance();
+    if (!fastify.hasContentTypeParser('multipart')) {
+      fastify.register(multer.contentParser);
+    }
+  }
+}

--- a/packages/fastify-multer/src/lib/fastify-multer.module.ts
+++ b/packages/fastify-multer/src/lib/fastify-multer.module.ts
@@ -1,26 +1,11 @@
-import { Module, OnApplicationBootstrap } from '@nestjs/common';
-import { HttpAdapterHost } from '@nestjs/core';
-import { FastifyAdapter } from '@nestjs/platform-fastify';
-import multer from 'fastify-multer';
+import { Module } from '@nestjs/common';
+import { FastifyCoreModule } from './fastify-multer-core.module';
 import { ConfigurableModuleClass } from './fastify-multer.module-definition';
 
 @Module({
+  imports: [FastifyCoreModule],
   controllers: [],
   providers: [],
   exports: [],
 })
-export class FastifyMulterModule
-  extends ConfigurableModuleClass
-  implements OnApplicationBootstrap
-{
-  constructor(private readonly appHost: HttpAdapterHost<FastifyAdapter>) {
-    super();
-  }
-
-  onApplicationBootstrap() {
-    const fastifyInstance = this.appHost.httpAdapter.getInstance();
-    if (!fastifyInstance.hasContentTypeParser('multipart/form-data')) {
-      fastifyInstance.register(multer.contentParser);
-    }
-  }
-}
+export class FastifyMulterModule extends ConfigurableModuleClass {}

--- a/packages/fastify-multer/test/file-upload/app/app.controller.ts
+++ b/packages/fastify-multer/test/file-upload/app/app.controller.ts
@@ -13,7 +13,7 @@ import {
   FileInterceptor,
   FilesInterceptor,
   NoFilesInterceptor,
-} from '../../src';
+} from '../../../src';
 
 @Controller()
 export class AppController {

--- a/packages/fastify-multer/test/file-upload/app/app.module.ts
+++ b/packages/fastify-multer/test/file-upload/app/app.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { FastifyMulterModule } from '../../src';
+import { FastifyMulterModule } from '../../../src';
 import { AppController } from './app.controller';
 
 @Module({

--- a/packages/fastify-multer/test/file-upload/file-upload.spec.ts
+++ b/packages/fastify-multer/test/file-upload/file-upload.spec.ts
@@ -5,17 +5,15 @@ import { test } from 'node:test';
 import { request, spec } from 'pactum';
 import { AppModule } from './app/app.module';
 
-test('Fastify File Upload', { only: true }, async (t) => {
+export const uploadTests = test('Fastify File Upload', async (t) => {
   const modRef = await Test.createTestingModule({
     imports: [AppModule],
   }).compile();
   const app = modRef.createNestApplication(new FastifyAdapter());
   await app.listen(0);
   const url = await app.getUrl();
-  console.log(url.replace('[::1]', 'localhost'));
   request.setBaseUrl(url.replace('[::1]', 'localhost'));
-  t.runOnly(true);
-  await t.test('Single File Upload', { only: true }, async () => {
+  await t.test('Single File Upload', async () => {
     await spec()
       .post('/single')
       .withFile('file', join(process.cwd(), 'package.json'))
@@ -23,7 +21,7 @@ test('Fastify File Upload', { only: true }, async (t) => {
       .expectBody({ success: true })
       .toss();
   });
-  await t.test('Multiple File Uploads', { only: true }, async () => {
+  await t.test('Multiple File Uploads', async () => {
     await spec()
       .post('/multiple')
       .withFile('file', join(process.cwd(), 'package.json'))
@@ -33,7 +31,7 @@ test('Fastify File Upload', { only: true }, async (t) => {
       .expectBody({ success: true, fileCount: 2 })
       .toss();
   });
-  await t.test('Any File Upload', { only: true }, async () => {
+  await t.test('Any File Upload', async () => {
     await spec()
       .post('/any')
       .withFile('fil', join(process.cwd(), 'package.json'))
@@ -42,7 +40,7 @@ test('Fastify File Upload', { only: true }, async (t) => {
       .expectBody({ success: true, fileCount: 1 })
       .toss();
   });
-  await t.test('File Fields Upload - profile field', { only: true }, async () => {
+  await t.test('File Fields Upload - profile field', async () => {
     await spec()
       .post('/fields')
       .withFile('profile', join(process.cwd(), 'package.json'))
@@ -50,7 +48,7 @@ test('Fastify File Upload', { only: true }, async (t) => {
       .expectBody({ success: true, fileCount: 1 })
       .toss();
   });
-  await t.test('File Fields Upload - avatar field', { only: true }, async () => {
+  await t.test('File Fields Upload - avatar field', async () => {
     await spec()
       .post('/fields')
       .withFile('avatar', join(process.cwd(), 'package.json'))
@@ -58,7 +56,7 @@ test('Fastify File Upload', { only: true }, async (t) => {
       .expectBody({ success: true, fileCount: 1 })
       .toss();
   });
-  await t.test('File Fields Upload - profile and avatar fields', { only: true }, async () => {
+  await t.test('File Fields Upload - profile and avatar fields', async () => {
     await spec()
       .post('/fields')
       .withFile('profile', join(process.cwd(), 'package.json'))
@@ -67,7 +65,7 @@ test('Fastify File Upload', { only: true }, async (t) => {
       .expectBody({ success: true, fileCount: 2 })
       .toss();
   });
-  await t.test('No File Upload - 201, no file', { only: true }, async () => {
+  await t.test('No File Upload - 201, no file', async () => {
     await spec()
       .post('/none')
       .withMultiPartFormData('no', 'files')
@@ -75,7 +73,7 @@ test('Fastify File Upload', { only: true }, async (t) => {
       .expectBody({ success: true })
       .toss();
   });
-  await t.test('No File Upload - 400, with file', { only: true }, async () => {
+  await t.test('No File Upload - 400, with file', async () => {
     await spec()
       .post('/none')
       .withFile('file', join(process.cwd(), 'package.json'))

--- a/packages/fastify-multer/test/index.spec.ts
+++ b/packages/fastify-multer/test/index.spec.ts
@@ -1,0 +1,6 @@
+import { uploadTests } from './file-upload/file-upload.spec';
+import { multipleImportsTest } from './multiple-imports/multiple-imports.spec';
+
+(async () => {
+  await Promise.all([uploadTests, multipleImportsTest]);
+})();

--- a/packages/fastify-multer/test/multiple-imports/app/app.module.ts
+++ b/packages/fastify-multer/test/multiple-imports/app/app.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { BarModule } from '../bar/bar.module';
+import { FooModule } from '../foo/foo.module';
+
+@Module({
+  imports: [BarModule, FooModule],
+})
+export class AppModule {}

--- a/packages/fastify-multer/test/multiple-imports/bar/bar.module.ts
+++ b/packages/fastify-multer/test/multiple-imports/bar/bar.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { diskStorage } from 'fastify-multer/lib';
+import { FastifyMulterModule } from '../../../src';
+
+@Module({
+  imports: [
+    FastifyMulterModule.registerAsync({
+      useFactory: () => ({
+        storage: diskStorage({ destination: '/tmp/uploads/' }),
+      }),
+    }),
+  ],
+})
+export class BarModule {}

--- a/packages/fastify-multer/test/multiple-imports/foo/foo.module.ts
+++ b/packages/fastify-multer/test/multiple-imports/foo/foo.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { memoryStorage } from 'fastify-multer/lib';
+import { FastifyMulterModule } from '../../../src';
+
+@Module({
+  imports: [
+    FastifyMulterModule.registerAsync({
+      useFactory: () => ({
+        storage: memoryStorage(),
+      }),
+    }),
+  ],
+})
+export class FooModule {}

--- a/packages/fastify-multer/test/multiple-imports/multiple-imports.spec.ts
+++ b/packages/fastify-multer/test/multiple-imports/multiple-imports.spec.ts
@@ -1,0 +1,22 @@
+import assert = require('node:assert');
+import { Test } from '@nestjs/testing';
+import test from 'node:test';
+import { AppModule } from './app/app.module';
+import { FastifyAdapter } from '@nestjs/platform-fastify';
+
+export const multipleImportsTest = test('Multiple Import Tests', async (t) => {
+  await t.test('Should be true', async () => {
+    const modRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    const app = modRef.createNestApplication(new FastifyAdapter());
+    try {
+      await app.listen(0);
+      assert(app !== undefined);
+    } catch {
+      assert(false);
+    } finally {
+      await app.close();
+    }
+  });
+});


### PR DESCRIPTION
By moving the registration of the multipart content parser
to a separate core module, the core module only gets activated
once which allows for multiple `registerAsync` calls without
calling the `fastify.register()` multiple times. This should
resovle the error in #11.

fix: #11