### PR TITLE
fix: export interfaces and use options from fastify-multer

### DIFF
--- a/.changeset/smooth-parrots-give.md
+++ b/.changeset/smooth-parrots-give.md
@@ -1,0 +1,5 @@
+---
+'@nest-lab/fastify-multer': minor
+---
+
+export multer interface and use options from fastify-multer

--- a/packages/fastify-multer/src/lib/interfaces/index.ts
+++ b/packages/fastify-multer/src/lib/interfaces/index.ts
@@ -1,2 +1,3 @@
 export * from './multer-options.interface';
 export * from './file-uploads.interface';
+export *  from "fastify-multer/lib/interfaces";

--- a/packages/fastify-multer/src/lib/interfaces/multer-options.interface.ts
+++ b/packages/fastify-multer/src/lib/interfaces/multer-options.interface.ts
@@ -1,44 +1,11 @@
-import {FastifyRequest} from "fastify";
-import {StorageEngine, File} from "fastify-multer/lib/interfaces";
+import {Options} from "fastify-multer/lib/interfaces";
 
 
 /**
  * @see https://github.com/expressjs/multer
  */
-export interface MulterOptions {
-  dest?: string;
-  /** The storage engine to use for uploaded files. */
-  storage?: StorageEngine
-  /**
-   * An object specifying the size limits of the following optional properties. This object is passed to busboy
-   * directly, and the details of properties can be found on https://github.com/mscdex/busboy#busboy-methods
-   */
-  limits?: {
-    /** Max field name size (Default: 100 bytes) */
-    fieldNameSize?: number;
-    /** Max field value size (Default: 1MB) */
-    fieldSize?: number;
-    /** Max number of non- file fields (Default: Infinity) */
-    fields?: number;
-    /** For multipart forms, the max file size (in bytes)(Default: Infinity) */
-    fileSize?: number;
-    /** For multipart forms, the max number of file fields (Default: Infinity) */
-    files?: number;
-    /** For multipart forms, the max number of parts (fields + files)(Default: Infinity) */
-    parts?: number;
-    /** For multipart forms, the max number of header key=> value pairs to parse Default: 2000(same as node's http). */
-    headerPairs?: number;
-  };
+export interface MulterOptions extends Options{}
 
-  /** Keep the full path of files instead of just the base name (Default: false) */
-  preservePath?: boolean;
-
-  fileFilter?(
-    req: FastifyRequest,
-    file: File,
-    callback: (error: Error | null, acceptFile: boolean) => void,
-  ): void;
-}
 
 export interface MulterField {
   /** The field name. */


### PR DESCRIPTION
This PR exports all interfaces from `fastify-multer` and also makes the multer options to use `options` interface from the same package