### PR TITLE
feat: Make `options` optional

### DIFF
--- a/.changeset/serious-eels-eat.md
+++ b/.changeset/serious-eels-eat.md
@@ -1,0 +1,5 @@
+---
+'@nest-lab/typeschema': patch
+---
+
+fix: make `options` optional

--- a/packages/typeschema/src/lib/typeschema.pipe.ts
+++ b/packages/typeschema/src/lib/typeschema.pipe.ts
@@ -18,7 +18,7 @@ export class ValidationPipe implements PipeTransform {
   constructor(
     @Optional()
     @Inject(TypeschemaOptions)
-    private readonly options: ValidationPipeOptions,
+    private readonly options?: ValidationPipeOptions,
     @Optional() protected readonly logger?: Logger
   ) {}
   async transform(value: unknown, metadata: ArgumentMetadata) {


### PR DESCRIPTION
Currently `ValidationPipe` requires `options` to be defined, forcing you to include a default e.g. `{}`  if you don't have any options to specify.