### PR TITLE
feat: add dynamic expire

### DIFF
--- a/packages/throttler-storage-redis/src/throttler-storage-redis.service.ts
+++ b/packages/throttler-storage-redis/src/throttler-storage-redis.service.ts
@@ -46,6 +46,10 @@ export class ThrottlerStorageRedisService implements ThrottlerStorageRedis, OnMo
         timeToExpire = ttl
       end
 
+      if blockDuration < 0 then
+        blockDuration = timeToExpire
+      end
+
       local isBlocked = redis.call('GET', blockKey)
       local timeToBlockExpire = 0
 


### PR DESCRIPTION
This is to gather feedback, I really think an auto expire is missing from throttler: other rate limits like fastify-rate-limit automatically calculate the blockDuration by looking at the ttl of the key, which is what most people expect, see issue: https://github.com/nestjs/throttler/issues/2208

As `blockDuration` must be passed to the increment method, this is the only way that comes to my mind to implement dynamic expiry without making a breaking change (by passing `-1` or another negative value as blockDuration, which doesn't make sense anyway)

What do you think? Should we make this explicit in throttler, which might require a breaking change, or would this be acceptable in this lib if we document it properly?