### PR TITLE
fix: allow passing redis options

### DIFF
--- a/.changeset/lemon-birds-scream.md
+++ b/.changeset/lemon-birds-scream.md
@@ -1,0 +1,5 @@
+---
+'@nest-lab/throttler-storage-redis': minor
+---
+
+Add optional options to be passed when creating a new instance with URL.

--- a/packages/throttler-storage-redis/src/throttler-storage-redis.service.ts
+++ b/packages/throttler-storage-redis/src/throttler-storage-redis.service.ts
@@ -12,12 +12,12 @@ export class ThrottlerStorageRedisService implements ThrottlerStorageRedis, OnMo
   constructor(redis?: Redis);
   constructor(cluster?: Cluster);
   constructor(options?: RedisOptions);
-  constructor(url?: string);
-  constructor(redisOrOptions?: Redis | Cluster | RedisOptions | string) {
+  constructor(url?: string, options?: RedisOptions);
+  constructor(redisOrOptions?: Redis | Cluster | RedisOptions | string, options?: RedisOptions) {
     if (redisOrOptions instanceof Redis || redisOrOptions instanceof Cluster) {
       this.redis = redisOrOptions;
     } else if (typeof redisOrOptions === 'string') {
-      this.redis = new Redis(redisOrOptions as string);
+      this.redis = new Redis(redisOrOptions as string, options);
       this.disconnectRequired = true;
     } else {
       this.redis = new Redis(redisOrOptions as RedisOptions);

--- a/packages/throttler-storage-redis/src/throttler-storage-redis.service.ts
+++ b/packages/throttler-storage-redis/src/throttler-storage-redis.service.ts
@@ -17,7 +17,7 @@ export class ThrottlerStorageRedisService implements ThrottlerStorageRedis, OnMo
     if (redisOrOptions instanceof Redis || redisOrOptions instanceof Cluster) {
       this.redis = redisOrOptions;
     } else if (typeof redisOrOptions === 'string') {
-      this.redis = new Redis(redisOrOptions as string, options);
+      this.redis = new Redis(redisOrOptions as string, options ?? {});
       this.disconnectRequired = true;
     } else {
       this.redis = new Redis(redisOrOptions as RedisOptions);


### PR DESCRIPTION
Add optional `options` to be passed when creating a new instance with URL.

This is useful when you want to create a connection with some custom options. For example fly io requires usage of IPv6:

```typescript
ThrottlerModule.forRoot({
  throttlers: [{ limit: 10, ttl: seconds(1) }],
  storage: new ThrottlerStorageRedisService(redisUrl, { family: 6 }),
}),
```