### PR TITLE
feat: add @nest-lab/busboy for Fastify v5 and Express file upload support

### DIFF
--- a/.changeset/ninety-starfishes-itch.md
+++ b/.changeset/ninety-starfishes-itch.md
@@ -1,0 +1,6 @@
+---
+'@nest-lab/busboy': major
+'@nest-lab/fastify-multer': minor
+---
+
+Add @nest-lab/busboy — file upload support for NestJS that works with both the Fastify and Express adapters, built directly on @fastify/busboy. Fixes compatibility with Fastify v5, which broke @nest-lab/fastify-multer due to stricter content-type parser matching. Supports the same interceptors (FileInterceptor, FilesInterceptor, FileFieldsInterceptor, AnyFilesInterceptor, NoFilesInterceptor), storage engines (memoryStorage, diskStorage), and options as @nestjs/platform-express's MulterModule.

--- a/packages/busboy/.eslintrc.json
+++ b/packages/busboy/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/busboy/README.md
+++ b/packages/busboy/README.md
@@ -1,0 +1,168 @@
+# @nest-lab/busboy
+
+File upload support for NestJS that works with **both** the Fastify and Express adapters, built directly on [`@fastify/busboy`](https://github.com/fastify/busboy) (the underlying multipart parser).
+
+This package replaces [`@nest-lab/fastify-multer`](../fastify-multer/README.md), which depends on the unmaintained `fastify-multer` library and does not support Fastify v5.
+
+## Installation
+
+```shell
+npm i @nest-lab/busboy
+yarn add @nest-lab/busboy
+pnpm i @nest-lab/busboy
+```
+
+## Usage
+
+Use this exactly like you would the [`MulterModule`](https://docs.nestjs.com/techniques/file-upload) from `@nestjs/platform-express`. The same interceptors, storage engines, and options are supported.
+
+You **must** import `BusboyModule` somewhere in your application so that the `multipart/form-data` content-type parser is registered with Fastify (on Express this step is a no-op).
+
+### Basic setup
+
+```typescript
+import { BusboyModule } from '@nest-lab/busboy';
+
+@Module({
+  imports: [BusboyModule],
+})
+export class AppModule {}
+```
+
+### Module-level options
+
+```typescript
+import { BusboyModule, memoryStorage } from '@nest-lab/busboy';
+
+@Module({
+  imports: [
+    BusboyModule.register({
+      storage: memoryStorage(),
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+### Async options
+
+```typescript
+@Module({
+  imports: [
+    BusboyModule.registerAsync({
+      useFactory: (config: ConfigService) => ({
+        dest: config.get('UPLOAD_DIR'),
+      }),
+      inject: [ConfigService],
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+### Interceptors
+
+All interceptors accept an optional `localOptions` argument that is merged with module-level options.
+
+```typescript
+import {
+  AnyFilesInterceptor,
+  FileFieldsInterceptor,
+  FileInterceptor,
+  FilesInterceptor,
+  NoFilesInterceptor,
+  memoryStorage,
+} from '@nest-lab/busboy';
+
+@Controller('upload')
+export class UploadController {
+  // Single file from field "file"
+  @Post('single')
+  @UseInterceptors(FileInterceptor('file', { storage: memoryStorage() }))
+  uploadSingle(@UploadedFile() file: Express.Multer.File) { ... }
+
+  // Up to 10 files from field "files"
+  @Post('multiple')
+  @UseInterceptors(FilesInterceptor('files', 10, { storage: memoryStorage() }))
+  uploadMultiple(@UploadedFiles() files: Express.Multer.File[]) { ... }
+
+  // Any files from any field
+  @Post('any')
+  @UseInterceptors(AnyFilesInterceptor({ storage: memoryStorage() }))
+  uploadAny(@UploadedFiles() files: Express.Multer.File[]) { ... }
+
+  // Named fields
+  @Post('fields')
+  @UseInterceptors(
+    FileFieldsInterceptor([{ name: 'avatar' }, { name: 'cover', maxCount: 1 }], {
+      storage: memoryStorage(),
+    }),
+  )
+  uploadFields(@UploadedFiles() files: { avatar?: Express.Multer.File[]; cover?: Express.Multer.File[] }) { ... }
+
+  // No files allowed — parses form fields only
+  @Post('form')
+  @UseInterceptors(NoFilesInterceptor())
+  formData(@Body() body: Record<string, string>) { ... }
+}
+```
+
+### Storage engines
+
+#### Memory storage (default)
+
+Files are buffered in memory as `Buffer` objects. This is the default when neither `storage` nor `dest` is specified.
+
+```typescript
+import { memoryStorage } from '@nest-lab/busboy';
+
+FileInterceptor('file', { storage: memoryStorage() })
+```
+
+#### Disk storage
+
+Files are written to disk. The destination directory is created automatically.
+
+```typescript
+import { diskStorage } from '@nest-lab/busboy';
+
+FileInterceptor('file', {
+  storage: diskStorage({
+    destination: '/uploads',
+    filename: (req, file, cb) => cb(null, `${Date.now()}-${file.originalname}`),
+  }),
+})
+```
+
+Or use the `dest` shorthand (generates random filenames):
+
+```typescript
+BusboyModule.register({ dest: '/uploads' })
+```
+
+### Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `storage` | `StorageEngine` | Custom storage engine. Defaults to `MemoryStorage`. |
+| `dest` | `string` | Destination directory. Uses `DiskStorage` with random filenames. |
+| `fileFilter` | `FileFilter` | Function to control which files are accepted. |
+| `limits` | `BusboyLimits` | Limits on incoming data (file size, file count, etc.). |
+| `preservePath` | `boolean` | Preserve the full path of the original filename. |
+
+## Migrating from `@nest-lab/fastify-multer`
+
+1. Replace `@nest-lab/fastify-multer` with `@nest-lab/busboy` in your dependencies.
+2. Replace `FastifyMulterModule` with `BusboyModule` in your imports.
+3. Replace `memoryStorage` / `diskStorage` imports — they now come from `@nest-lab/busboy` directly instead of `fastify-multer/lib`.
+
+```diff
+-import { FastifyMulterModule } from '@nest-lab/fastify-multer';
+-import { memoryStorage } from 'fastify-multer/lib';
++import { BusboyModule, memoryStorage } from '@nest-lab/busboy';
+
+-FastifyMulterModule.register({ ... })
++BusboyModule.register({ ... })
+```
+
+All interceptor names and options are identical.

--- a/packages/busboy/package.json
+++ b/packages/busboy/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@nest-lab/busboy",
+  "version": "1.0.0",
+  "description": "A File Upload package for NestJS supporting both Fastify and Express adapters",
+  "keywords": [
+    "fastify",
+    "express",
+    "nestjs",
+    "file upload",
+    "busboy",
+    "multipart"
+  ],
+  "license": "MIT",
+  "author": {
+    "name": "Jay McDoniel",
+    "email": "me@jaymcdoniel.dev"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "github",
+    "url": "https://github.com/jmcdo29/nest-lab",
+    "directory": "packages/busboy"
+  },
+  "bugs": {
+    "url": "https://github.com/jmcdo29/nest-lab/issues"
+  },
+  "type": "commonjs",
+  "dependencies": {
+    "@fastify/busboy": "^3.0.0"
+  },
+  "peerDependencies": {
+    "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0",
+    "@nestjs/platform-express": "^9.0.0 || ^10.0.0 || ^11.0.0",
+    "@nestjs/platform-fastify": "^9.0.0 || ^10.0.0 || ^11.0.0",
+    "rxjs": "^7.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@nestjs/common": {
+      "optional": false
+    },
+    "@nestjs/platform-express": {
+      "optional": true
+    },
+    "@nestjs/platform-fastify": {
+      "optional": true
+    },
+    "rxjs": {
+      "optional": false
+    }
+  }
+}

--- a/packages/busboy/project.json
+++ b/packages/busboy/project.json
@@ -1,0 +1,49 @@
+{
+  "name": "busboy",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/busboy/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nrwl/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/packages/busboy",
+        "tsConfig": "packages/busboy/tsconfig.lib.json",
+        "packageJson": "packages/busboy/package.json",
+        "main": "packages/busboy/src/index.ts",
+        "assets": ["packages/busboy/*.md"],
+        "updateBuildableProjectDepsInPackageJson": true,
+        "buildableProjectDepsInPackageJsonType": "dependencies"
+      }
+    },
+    "publish": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "dist/packages/busboy",
+        "command": "pnpm publish"
+      },
+      "dependsOn": [
+        {
+          "target": "build"
+        }
+      ]
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"]
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "node -r @swc/register --test packages/busboy/test/index.spec.ts"
+      },
+      "configurations": {
+        "local": {
+          "command": "node -r @swc/register packages/busboy/test/index.spec.ts"
+        }
+      }
+    }
+  },
+  "tags": []
+}

--- a/packages/busboy/src/index.ts
+++ b/packages/busboy/src/index.ts
@@ -1,0 +1,5 @@
+export * from './lib/busboy.module';
+export * from './lib/interceptors';
+export * from './lib/interfaces';
+export { diskStorage, memoryStorage } from './lib/storage';
+export type { DiskStorageOptions } from './lib/storage';

--- a/packages/busboy/src/lib/busboy-core.module.ts
+++ b/packages/busboy/src/lib/busboy-core.module.ts
@@ -1,0 +1,30 @@
+import { Module, OnApplicationBootstrap } from '@nestjs/common';
+import { HttpAdapterHost } from '@nestjs/core';
+
+@Module({})
+export class BusboyCoreModule implements OnApplicationBootstrap {
+  constructor(private readonly httpAdapterHost: HttpAdapterHost) {}
+
+  onApplicationBootstrap() {
+    const adapter = this.httpAdapterHost.httpAdapter;
+    const instance = adapter.getInstance();
+
+    // Detect Fastify by the presence of addContentTypeParser
+    if (typeof instance?.addContentTypeParser === 'function') {
+      // Register a regex-based content-type parser to handle multipart/form-data
+      // including the boundary parameter (e.g. "multipart/form-data; boundary=xxxx").
+      // This prevents Fastify v5's FST_ERR_CTP_INVALID_MEDIA_TYPE error.
+      // The raw payload stream is stored as req.body so interceptors can pipe it.
+      if (!instance.hasContentTypeParser('multipart/form-data')) {
+        instance.addContentTypeParser(
+          /^multipart\/form-data/,
+          (req: unknown, payload: unknown, done: (err: Error | null, body?: unknown) => void) => {
+            done(null, payload);
+          },
+        );
+      }
+    }
+    // Express: body-parser does not handle multipart/form-data, so no registration needed.
+    // The raw req stream remains available for interceptors to pipe through busboy.
+  }
+}

--- a/packages/busboy/src/lib/busboy.module-definition.ts
+++ b/packages/busboy/src/lib/busboy.module-definition.ts
@@ -1,0 +1,5 @@
+import { ConfigurableModuleBuilder } from '@nestjs/common';
+import type { BusboyModuleOptions } from './interfaces';
+
+export const { ConfigurableModuleClass, MODULE_OPTIONS_TOKEN } =
+  new ConfigurableModuleBuilder<BusboyModuleOptions>().build();

--- a/packages/busboy/src/lib/busboy.module.ts
+++ b/packages/busboy/src/lib/busboy.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { BusboyCoreModule } from './busboy-core.module';
+import { ConfigurableModuleClass, MODULE_OPTIONS_TOKEN } from './busboy.module-definition';
+import { BUSBOY_OPTIONS } from './files.constants';
+import type { BusboyModuleOptions } from './interfaces';
+
+@Module({
+  imports: [BusboyCoreModule],
+  providers: [
+    {
+      provide: BUSBOY_OPTIONS,
+      useFactory: (options?: BusboyModuleOptions) => ({ ...(options ?? {}) }),
+      inject: [{ token: MODULE_OPTIONS_TOKEN, optional: true }],
+    },
+  ],
+  exports: [BUSBOY_OPTIONS],
+})
+export class BusboyModule extends ConfigurableModuleClass {}

--- a/packages/busboy/src/lib/files.constants.ts
+++ b/packages/busboy/src/lib/files.constants.ts
@@ -1,0 +1,1 @@
+export const BUSBOY_OPTIONS = 'BUSBOY_OPTIONS';

--- a/packages/busboy/src/lib/interceptors/any-files.interceptor.ts
+++ b/packages/busboy/src/lib/interceptors/any-files.interceptor.ts
@@ -1,0 +1,46 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Inject,
+  mixin,
+  NestInterceptor,
+  Optional,
+  Type,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { BUSBOY_OPTIONS } from '../files.constants';
+import type { BusboyModuleOptions, BusboyOptions } from '../interfaces';
+import { parseMultipart } from '../utils/parse-multipart';
+import { transformException } from '../utils/transform-exception';
+
+export function AnyFilesInterceptor(
+  localOptions?: BusboyOptions,
+): Type<NestInterceptor> {
+  class MixinInterceptor implements NestInterceptor {
+    constructor(
+      @Optional()
+      @Inject(BUSBOY_OPTIONS)
+      private readonly options: BusboyModuleOptions = {},
+    ) {}
+
+    async intercept(
+      context: ExecutionContext,
+      next: CallHandler,
+    ): Promise<Observable<unknown>> {
+      const req = context.switchToHttp().getRequest();
+      const mergedOptions = { ...this.options, ...localOptions };
+
+      try {
+        const { files, body } = await parseMultipart(req, mergedOptions, 'any');
+        req.files = files;
+        req.body = body;
+      } catch (err) {
+        throw transformException(err as Error);
+      }
+
+      return next.handle();
+    }
+  }
+
+  return mixin(MixinInterceptor);
+}

--- a/packages/busboy/src/lib/interceptors/file-fields.interceptor.ts
+++ b/packages/busboy/src/lib/interceptors/file-fields.interceptor.ts
@@ -1,0 +1,59 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Inject,
+  mixin,
+  NestInterceptor,
+  Optional,
+  Type,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { BUSBOY_OPTIONS } from '../files.constants';
+import type { BusboyModuleOptions, BusboyOptions, MulterField, MulterFile } from '../interfaces';
+import { parseMultipart } from '../utils/parse-multipart';
+import { transformException } from '../utils/transform-exception';
+
+export function FileFieldsInterceptor(
+  uploadFields: MulterField[],
+  localOptions?: BusboyOptions,
+): Type<NestInterceptor> {
+  class MixinInterceptor implements NestInterceptor {
+    constructor(
+      @Optional()
+      @Inject(BUSBOY_OPTIONS)
+      private readonly options: BusboyModuleOptions = {},
+    ) {}
+
+    async intercept(
+      context: ExecutionContext,
+      next: CallHandler,
+    ): Promise<Observable<unknown>> {
+      const req = context.switchToHttp().getRequest();
+      const mergedOptions = { ...this.options, ...localOptions };
+
+      try {
+        const { files, body } = await parseMultipart(req, mergedOptions, 'fields', {
+          uploadFields,
+        });
+
+        // Group files by fieldname into an object
+        const grouped: Record<string, MulterFile[]> = {};
+        for (const file of files) {
+          if (!grouped[file.fieldname]) {
+            grouped[file.fieldname] = [];
+          }
+          grouped[file.fieldname].push(file);
+        }
+
+        req.files = grouped;
+        req.body = body;
+      } catch (err) {
+        throw transformException(err as Error);
+      }
+
+      return next.handle();
+    }
+  }
+
+  return mixin(MixinInterceptor);
+}

--- a/packages/busboy/src/lib/interceptors/file.interceptor.ts
+++ b/packages/busboy/src/lib/interceptors/file.interceptor.ts
@@ -1,0 +1,49 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Inject,
+  mixin,
+  NestInterceptor,
+  Optional,
+  Type,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { BUSBOY_OPTIONS } from '../files.constants';
+import type { BusboyModuleOptions, BusboyOptions } from '../interfaces';
+import { parseMultipart } from '../utils/parse-multipart';
+import { transformException } from '../utils/transform-exception';
+
+export function FileInterceptor(
+  fieldName: string,
+  localOptions?: BusboyOptions,
+): Type<NestInterceptor> {
+  class MixinInterceptor implements NestInterceptor {
+    constructor(
+      @Optional()
+      @Inject(BUSBOY_OPTIONS)
+      private readonly options: BusboyModuleOptions = {},
+    ) {}
+
+    async intercept(
+      context: ExecutionContext,
+      next: CallHandler,
+    ): Promise<Observable<unknown>> {
+      const req = context.switchToHttp().getRequest();
+      const mergedOptions = { ...this.options, ...localOptions };
+
+      try {
+        const { files, body } = await parseMultipart(req, mergedOptions, 'single', {
+          fieldName,
+        });
+        req.file = files[0] ?? undefined;
+        req.body = body;
+      } catch (err) {
+        throw transformException(err as Error);
+      }
+
+      return next.handle();
+    }
+  }
+
+  return mixin(MixinInterceptor);
+}

--- a/packages/busboy/src/lib/interceptors/files.interceptor.ts
+++ b/packages/busboy/src/lib/interceptors/files.interceptor.ts
@@ -1,0 +1,51 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Inject,
+  mixin,
+  NestInterceptor,
+  Optional,
+  Type,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { BUSBOY_OPTIONS } from '../files.constants';
+import type { BusboyModuleOptions, BusboyOptions } from '../interfaces';
+import { parseMultipart } from '../utils/parse-multipart';
+import { transformException } from '../utils/transform-exception';
+
+export function FilesInterceptor(
+  fieldName: string,
+  maxCount?: number,
+  localOptions?: BusboyOptions,
+): Type<NestInterceptor> {
+  class MixinInterceptor implements NestInterceptor {
+    constructor(
+      @Optional()
+      @Inject(BUSBOY_OPTIONS)
+      private readonly options: BusboyModuleOptions = {},
+    ) {}
+
+    async intercept(
+      context: ExecutionContext,
+      next: CallHandler,
+    ): Promise<Observable<unknown>> {
+      const req = context.switchToHttp().getRequest();
+      const mergedOptions = { ...this.options, ...localOptions };
+
+      try {
+        const { files, body } = await parseMultipart(req, mergedOptions, 'array', {
+          fieldName,
+          maxCount,
+        });
+        req.files = files;
+        req.body = body;
+      } catch (err) {
+        throw transformException(err as Error);
+      }
+
+      return next.handle();
+    }
+  }
+
+  return mixin(MixinInterceptor);
+}

--- a/packages/busboy/src/lib/interceptors/index.ts
+++ b/packages/busboy/src/lib/interceptors/index.ts
@@ -1,0 +1,5 @@
+export * from './any-files.interceptor';
+export * from './file-fields.interceptor';
+export * from './file.interceptor';
+export * from './files.interceptor';
+export * from './no-files.interceptor';

--- a/packages/busboy/src/lib/interceptors/no-files.interceptor.ts
+++ b/packages/busboy/src/lib/interceptors/no-files.interceptor.ts
@@ -1,0 +1,42 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Inject,
+  mixin,
+  NestInterceptor,
+  Optional,
+  Type,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { BUSBOY_OPTIONS } from '../files.constants';
+import type { BusboyModuleOptions } from '../interfaces';
+import { parseMultipart } from '../utils/parse-multipart';
+import { transformException } from '../utils/transform-exception';
+
+export function NoFilesInterceptor(): Type<NestInterceptor> {
+  class MixinInterceptor implements NestInterceptor {
+    constructor(
+      @Optional()
+      @Inject(BUSBOY_OPTIONS)
+      private readonly options: BusboyModuleOptions = {},
+    ) {}
+
+    async intercept(
+      context: ExecutionContext,
+      next: CallHandler,
+    ): Promise<Observable<unknown>> {
+      const req = context.switchToHttp().getRequest();
+
+      try {
+        const { body } = await parseMultipart(req, this.options, 'none');
+        req.body = body;
+      } catch (err) {
+        throw transformException(err as Error);
+      }
+
+      return next.handle();
+    }
+  }
+
+  return mixin(MixinInterceptor);
+}

--- a/packages/busboy/src/lib/interfaces/busboy-options.interface.ts
+++ b/packages/busboy/src/lib/interfaces/busboy-options.interface.ts
@@ -1,0 +1,82 @@
+import type { Readable } from 'stream';
+
+export interface MulterFile {
+  /** The field name as specified in the HTML form. */
+  fieldname: string;
+  /** The name of the uploaded file. */
+  originalname: string;
+  /** Encoding type of the file. */
+  encoding: string;
+  /** Mime type of the file. */
+  mimetype: string;
+  /** Size of the file in bytes. */
+  size: number;
+  /** The folder to which the file has been saved (DiskStorage). */
+  destination?: string;
+  /** The name of the file within the destination (DiskStorage). */
+  filename?: string;
+  /** The full path to the uploaded file (DiskStorage). */
+  path?: string;
+  /** A Buffer of the entire file (MemoryStorage). */
+  buffer?: Buffer;
+  /** The readable stream of the file. */
+  stream?: Readable;
+}
+
+export interface StorageEngine {
+  _handleFile(
+    req: any,
+    file: Pick<MulterFile, 'fieldname' | 'originalname' | 'encoding' | 'mimetype'> & {
+      stream: Readable;
+    },
+    callback: (error: Error | null, info?: Partial<MulterFile>) => void,
+  ): void;
+  _removeFile(
+    req: any,
+    file: MulterFile,
+    callback: (error: Error | null) => void,
+  ): void;
+}
+
+export type FileFilter = (
+  req: any,
+  file: Pick<MulterFile, 'fieldname' | 'originalname' | 'encoding' | 'mimetype'>,
+  callback: (error: Error | null, acceptFile: boolean) => void,
+) => void;
+
+export interface MulterField {
+  /** The field name. */
+  name: string;
+  /** Optional maximum number of files per field to accept. */
+  maxCount?: number;
+}
+
+export interface BusboyLimits {
+  /** Max field name size (in bytes). Default: 100 bytes. */
+  fieldNameSize?: number;
+  /** Max field value size (in bytes). Default: 1MB. */
+  fieldSize?: number;
+  /** Max number of non-file fields. Default: Infinity. */
+  fields?: number;
+  /** Max file size (in bytes). Default: Infinity. */
+  fileSize?: number;
+  /** Max number of file fields. Default: Infinity. */
+  files?: number;
+  /** Max number of parts (fields + files). Default: Infinity. */
+  parts?: number;
+  /** Max number of header key-value pairs. Default: 2000. */
+  headerPairs?: number;
+}
+
+export interface BusboyOptions {
+  /** The storage engine to use for uploaded files. Defaults to MemoryStorage. */
+  storage?: StorageEngine;
+  /** The destination directory for uploaded files. If set, uses DiskStorage. */
+  dest?: string;
+  /** Function to control which files are accepted. */
+  fileFilter?: FileFilter;
+  /** Limits on the incoming data. */
+  limits?: BusboyLimits;
+  /** Whether to preserve the full path of the original filename. */
+  preservePath?: boolean;
+}

--- a/packages/busboy/src/lib/interfaces/file-uploads.interface.ts
+++ b/packages/busboy/src/lib/interfaces/file-uploads.interface.ts
@@ -1,0 +1,15 @@
+import type { ModuleMetadata, Type } from '@nestjs/common';
+import type { BusboyOptions } from './busboy-options.interface';
+
+export type BusboyModuleOptions = BusboyOptions;
+
+export interface BusboyOptionsFactory {
+  createBusboyOptions(): Promise<BusboyModuleOptions> | BusboyModuleOptions;
+}
+
+export interface BusboyModuleAsyncOptions extends Pick<ModuleMetadata, 'imports'> {
+  useExisting?: Type<BusboyOptionsFactory>;
+  useClass?: Type<BusboyOptionsFactory>;
+  useFactory?: (...args: any[]) => Promise<BusboyModuleOptions> | BusboyModuleOptions;
+  inject?: any[];
+}

--- a/packages/busboy/src/lib/interfaces/index.ts
+++ b/packages/busboy/src/lib/interfaces/index.ts
@@ -1,0 +1,2 @@
+export * from './busboy-options.interface';
+export * from './file-uploads.interface';

--- a/packages/busboy/src/lib/storage/disk.storage.ts
+++ b/packages/busboy/src/lib/storage/disk.storage.ts
@@ -1,0 +1,96 @@
+import { randomBytes } from 'crypto';
+import { createWriteStream, mkdir, unlink } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import type { Readable } from 'stream';
+import type { MulterFile, StorageEngine } from '../interfaces';
+
+type DestinationCallback = (error: Error | null, destination: string) => void;
+type FilenameCallback = (error: Error | null, filename: string) => void;
+
+export interface DiskStorageOptions {
+  destination?:
+    | string
+    | ((req: any, file: Partial<MulterFile>, callback: DestinationCallback) => void);
+  filename?: (req: any, file: Partial<MulterFile>, callback: FilenameCallback) => void;
+}
+
+export class DiskStorage implements StorageEngine {
+  private readonly getDestination: (
+    req: any,
+    file: Partial<MulterFile>,
+    callback: DestinationCallback,
+  ) => void;
+
+  private readonly getFilename: (
+    req: any,
+    file: Partial<MulterFile>,
+    callback: FilenameCallback,
+  ) => void;
+
+  constructor(opts: DiskStorageOptions = {}) {
+    if (typeof opts.destination === 'function') {
+      this.getDestination = opts.destination;
+    } else {
+      const dest = opts.destination ?? tmpdir();
+      this.getDestination = (_req, _file, cb) => cb(null, dest as string);
+    }
+
+    if (opts.filename) {
+      this.getFilename = opts.filename;
+    } else {
+      this.getFilename = (_req, _file, cb) => {
+        randomBytes(16, (err: Error | null, raw: Buffer) => {
+          cb(err, err ? '' : raw.toString('hex'));
+        });
+      };
+    }
+  }
+
+  _handleFile(
+    req: any,
+    file: Pick<MulterFile, 'fieldname' | 'originalname' | 'encoding' | 'mimetype'> & {
+      stream: Readable;
+    },
+    callback: (error: Error | null, info?: Partial<MulterFile>) => void,
+  ): void {
+    this.getDestination(req, file, (destErr, destination) => {
+      if (destErr) return callback(destErr);
+
+      this.getFilename(req, file, (nameErr, filename) => {
+        if (nameErr) return callback(nameErr);
+
+        mkdir(destination, { recursive: true }, (mkdirErr) => {
+          if (mkdirErr) return callback(mkdirErr);
+
+          const finalPath = join(destination, filename);
+          const outStream = createWriteStream(finalPath);
+
+          file.stream.pipe(outStream);
+          outStream.on('error', callback);
+          outStream.on('finish', () => {
+            callback(null, {
+              destination,
+              filename,
+              path: finalPath,
+              size: outStream.bytesWritten,
+            });
+          });
+        });
+      });
+    });
+  }
+
+  _removeFile(
+    _req: any,
+    file: MulterFile,
+    callback: (error: Error | null) => void,
+  ): void {
+    if (!file.path) return callback(null);
+    unlink(file.path, callback);
+  }
+}
+
+export function diskStorage(opts: DiskStorageOptions = {}): StorageEngine {
+  return new DiskStorage(opts);
+}

--- a/packages/busboy/src/lib/storage/index.ts
+++ b/packages/busboy/src/lib/storage/index.ts
@@ -1,0 +1,3 @@
+export { diskStorage, DiskStorage } from './disk.storage';
+export type { DiskStorageOptions } from './disk.storage';
+export { memoryStorage, MemoryStorage } from './memory.storage';

--- a/packages/busboy/src/lib/storage/memory.storage.ts
+++ b/packages/busboy/src/lib/storage/memory.storage.ts
@@ -1,0 +1,33 @@
+import type { Readable } from 'stream';
+import type { MulterFile, StorageEngine } from '../interfaces';
+
+export class MemoryStorage implements StorageEngine {
+  _handleFile(
+    _req: any,
+    file: Pick<MulterFile, 'fieldname' | 'originalname' | 'encoding' | 'mimetype'> & {
+      stream: Readable;
+    },
+    callback: (error: Error | null, info?: Partial<MulterFile>) => void,
+  ): void {
+    const chunks: Buffer[] = [];
+    file.stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+    file.stream.on('end', () => {
+      const buffer = Buffer.concat(chunks);
+      callback(null, { buffer, size: buffer.length });
+    });
+    file.stream.on('error', callback);
+  }
+
+  _removeFile(
+    _req: any,
+    file: MulterFile,
+    callback: (error: Error | null) => void,
+  ): void {
+    delete file.buffer;
+    callback(null);
+  }
+}
+
+export function memoryStorage(): StorageEngine {
+  return new MemoryStorage();
+}

--- a/packages/busboy/src/lib/utils/busboy.constants.ts
+++ b/packages/busboy/src/lib/utils/busboy.constants.ts
@@ -1,0 +1,9 @@
+export const busboyExceptions = {
+  LIMIT_PART_COUNT: 'Too many parts',
+  LIMIT_FILE_SIZE: 'File too large',
+  LIMIT_FILE_COUNT: 'Too many files',
+  LIMIT_FIELD_KEY: 'Field name too long',
+  LIMIT_FIELD_VALUE: 'Field value too long',
+  LIMIT_FIELD_COUNT: 'Too many fields',
+  LIMIT_UNEXPECTED_FILE: 'Unexpected field',
+} as const;

--- a/packages/busboy/src/lib/utils/index.ts
+++ b/packages/busboy/src/lib/utils/index.ts
@@ -1,0 +1,3 @@
+export * from './busboy.constants';
+export * from './parse-multipart';
+export * from './transform-exception';

--- a/packages/busboy/src/lib/utils/parse-multipart.ts
+++ b/packages/busboy/src/lib/utils/parse-multipart.ts
@@ -1,0 +1,182 @@
+import { Busboy, type BusboyHeaders } from '@fastify/busboy';
+import type { Readable } from 'stream';
+import type { BusboyOptions, MulterFile, StorageEngine } from '../interfaces';
+import { diskStorage } from '../storage/disk.storage';
+import { memoryStorage } from '../storage/memory.storage';
+import { busboyExceptions } from './busboy.constants';
+
+export type ParseMode = 'single' | 'array' | 'fields' | 'any' | 'none';
+
+export interface ParseConstraints {
+  fieldName?: string;
+  maxCount?: number;
+  uploadFields?: Array<{ name: string; maxCount?: number }>;
+}
+
+export function getStream(req: any): Readable {
+  // Fastify: our content-type parser stores the raw payload as req.body
+  if (req.body != null && typeof (req.body as any).pipe === 'function') {
+    return req.body as Readable;
+  }
+  // Express: req IS the IncomingMessage stream
+  // Fastify (no parser registered): req.raw is the IncomingMessage
+  return (req as any).raw ?? req;
+}
+
+export function resolveStorage(options: BusboyOptions): StorageEngine {
+  if (options.storage) return options.storage;
+  if (options.dest) return diskStorage({ destination: options.dest });
+  return memoryStorage();
+}
+
+export function parseMultipart(
+  req: any,
+  options: BusboyOptions,
+  mode: ParseMode,
+  constraints: ParseConstraints = {},
+): Promise<{ files: MulterFile[]; body: Record<string, string | string[]> }> {
+  return new Promise((resolve, reject) => {
+    const stream = getStream(req);
+    const headers = req.headers as BusboyHeaders;
+    const storage = resolveStorage(options);
+
+    const bb = new Busboy({
+      headers,
+      limits: options.limits,
+      preservePath: options.preservePath,
+    });
+
+    const files: MulterFile[] = [];
+    const body: Record<string, string | string[]> = {};
+    const pending: Promise<void>[] = [];
+    let firstError: Error | null = null;
+
+    // @fastify/busboy file event: (fieldname, stream, filename, encoding, mimeType)
+    bb.on('file', (fieldname: string, fileStream: Readable, originalname: string, encoding: string, mimetype: string) => {
+      // none mode: reject any file
+      if (mode === 'none') {
+        fileStream.resume();
+        firstError ??= new Error(busboyExceptions.LIMIT_UNEXPECTED_FILE);
+        return;
+      }
+
+      // single/array mode: only accept the specified field
+      if (
+        (mode === 'single' || mode === 'array') &&
+        constraints.fieldName != null &&
+        fieldname !== constraints.fieldName
+      ) {
+        fileStream.resume();
+        firstError ??= new Error(busboyExceptions.LIMIT_UNEXPECTED_FILE);
+        return;
+      }
+
+      // array mode: check maxCount
+      if (mode === 'array' && constraints.maxCount != null) {
+        const existing = files.filter((f) => f.fieldname === fieldname).length;
+        if (existing >= constraints.maxCount) {
+          fileStream.resume();
+          firstError ??= new Error(busboyExceptions.LIMIT_FILE_COUNT);
+          return;
+        }
+      }
+
+      // fields mode: validate against uploadFields list
+      if (mode === 'fields' && constraints.uploadFields) {
+        const fieldDef = constraints.uploadFields.find((f) => f.name === fieldname);
+        if (!fieldDef) {
+          fileStream.resume();
+          firstError ??= new Error(busboyExceptions.LIMIT_UNEXPECTED_FILE);
+          return;
+        }
+        if (fieldDef.maxCount != null) {
+          const existing = files.filter((f) => f.fieldname === fieldname).length;
+          if (existing >= fieldDef.maxCount) {
+            fileStream.resume();
+            firstError ??= new Error(busboyExceptions.LIMIT_FILE_COUNT);
+            return;
+          }
+        }
+      }
+
+      const fileInfo = { fieldname, originalname, encoding, mimetype };
+
+      const processFile = async (): Promise<void> => {
+        // Apply file filter
+        if (options.fileFilter) {
+          const accepted = await new Promise<boolean>((res, rej) => {
+            options.fileFilter!(req, fileInfo as any, (err, accept) => {
+              if (err) rej(err);
+              else res(accept);
+            });
+          });
+          if (!accepted) {
+            fileStream.resume();
+            return;
+          }
+        }
+
+        const storedInfo = await new Promise<Partial<MulterFile>>((res, rej) => {
+          storage._handleFile(req, { ...fileInfo, stream: fileStream }, (err, info) => {
+            if (err) rej(err);
+            else res(info ?? {});
+          });
+        });
+
+        // Check if file was truncated due to fileSize limit
+        if ((fileStream as any).truncated) {
+          firstError ??= new Error(busboyExceptions.LIMIT_FILE_SIZE);
+          return;
+        }
+
+        files.push({ ...fileInfo, size: storedInfo.size ?? 0, ...storedInfo } as MulterFile);
+      };
+
+      pending.push(processFile());
+    });
+
+    bb.on('field', (fieldname: string, value: string) => {
+      if (Object.prototype.hasOwnProperty.call(body, fieldname)) {
+        const existing = body[fieldname];
+        if (Array.isArray(existing)) {
+          existing.push(value);
+        } else {
+          body[fieldname] = [existing as string, value];
+        }
+      } else {
+        body[fieldname] = value;
+      }
+    });
+
+    bb.on('filesLimit', () => {
+      firstError ??= new Error(busboyExceptions.LIMIT_FILE_COUNT);
+    });
+
+    bb.on('fieldsLimit', () => {
+      firstError ??= new Error(busboyExceptions.LIMIT_FIELD_COUNT);
+    });
+
+    bb.on('partsLimit', () => {
+      firstError ??= new Error(busboyExceptions.LIMIT_PART_COUNT);
+    });
+
+    bb.on('error', (err: Error) => {
+      reject(err);
+    });
+
+    bb.on('finish', () => {
+      Promise.all(pending).then(
+        () => {
+          if (firstError) {
+            reject(firstError);
+          } else {
+            resolve({ files, body });
+          }
+        },
+        (err) => reject(err),
+      );
+    });
+
+    stream.pipe(bb);
+  });
+}

--- a/packages/busboy/src/lib/utils/transform-exception.ts
+++ b/packages/busboy/src/lib/utils/transform-exception.ts
@@ -1,0 +1,24 @@
+import {
+  BadRequestException,
+  HttpException,
+  PayloadTooLargeException,
+} from '@nestjs/common';
+import { busboyExceptions } from './busboy.constants';
+
+export function transformException(error: Error | undefined) {
+  if (!error || error instanceof HttpException) {
+    return error;
+  }
+  switch (error.message) {
+    case busboyExceptions.LIMIT_FILE_SIZE:
+      return new PayloadTooLargeException(error.message);
+    case busboyExceptions.LIMIT_FILE_COUNT:
+    case busboyExceptions.LIMIT_FIELD_KEY:
+    case busboyExceptions.LIMIT_FIELD_VALUE:
+    case busboyExceptions.LIMIT_FIELD_COUNT:
+    case busboyExceptions.LIMIT_UNEXPECTED_FILE:
+    case busboyExceptions.LIMIT_PART_COUNT:
+      return new BadRequestException(error.message);
+  }
+  return error;
+}

--- a/packages/busboy/test/file-upload-express/app/app.controller.ts
+++ b/packages/busboy/test/file-upload-express/app/app.controller.ts
@@ -1,0 +1,62 @@
+import {
+  Body,
+  Controller,
+  Post,
+  UploadedFile,
+  UploadedFiles,
+  UseInterceptors,
+} from '@nestjs/common';
+import {
+  AnyFilesInterceptor,
+  FileFieldsInterceptor,
+  FileInterceptor,
+  FilesInterceptor,
+  NoFilesInterceptor,
+  memoryStorage,
+} from '../../../src';
+
+@Controller()
+export class AppController {
+  @Post('single')
+  @UseInterceptors(FileInterceptor('file', { storage: memoryStorage() }))
+  uploadSingleFile(@UploadedFile() file: unknown) {
+    return { success: !!file };
+  }
+
+  @Post('multiple')
+  @UseInterceptors(FilesInterceptor('file', 10, { storage: memoryStorage() }))
+  uploadMultipleFiles(@UploadedFiles() files: unknown[]) {
+    return { success: !!files.length, fileCount: files.length };
+  }
+
+  @Post('any')
+  @UseInterceptors(AnyFilesInterceptor({ storage: memoryStorage() }))
+  uploadAnyFiles(@UploadedFiles() files: unknown[]) {
+    return { success: !!files.length, fileCount: files.length };
+  }
+
+  @Post('fields')
+  @UseInterceptors(
+    FileFieldsInterceptor([{ name: 'profile' }, { name: 'avatar' }], {
+      storage: memoryStorage(),
+    }),
+  )
+  uploadFileFieldsFiles(
+    @UploadedFiles() files: { profile?: unknown[]; avatar?: unknown[] },
+  ) {
+    return {
+      success: !!((files.profile?.length ?? 0) + (files.avatar?.length ?? 0)),
+      fileCount: (files.profile?.length ?? 0) + (files.avatar?.length ?? 0),
+    };
+  }
+
+  @Post('none')
+  @UseInterceptors(NoFilesInterceptor())
+  noFilesAllowed(
+    @Body() body: Record<string, string>,
+    @UploadedFiles() files: unknown[],
+    @UploadedFile() file: unknown,
+  ) {
+    return { success: !files && !file && !!body };
+  }
+}

--- a/packages/busboy/test/file-upload-express/app/app.module.ts
+++ b/packages/busboy/test/file-upload-express/app/app.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { BusboyModule } from '../../../src';
+import { AppController } from './app.controller';
+
+@Module({
+  imports: [BusboyModule],
+  controllers: [AppController],
+})
+export class AppModule {}

--- a/packages/busboy/test/file-upload-express/file-upload-express.spec.ts
+++ b/packages/busboy/test/file-upload-express/file-upload-express.spec.ts
@@ -1,0 +1,93 @@
+import { ExpressAdapter } from '@nestjs/platform-express';
+import { Test } from '@nestjs/testing';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { request, spec } from 'pactum';
+import { AppModule } from './app/app.module';
+
+export const uploadExpressTests = test('Busboy File Upload - Express', async (t) => {
+  const modRef = await Test.createTestingModule({
+    imports: [AppModule],
+  }).compile();
+  const app = modRef.createNestApplication(new ExpressAdapter());
+  await app.listen(0);
+  const url = await app.getUrl();
+  request.setBaseUrl(url.replace('[::1]', 'localhost'));
+
+  await t.test('Single File Upload', async () => {
+    await spec()
+      .post('/single')
+      .withFile('file', join(process.cwd(), 'package.json'))
+      .expectStatus(201)
+      .expectBody({ success: true })
+      .toss();
+  });
+
+  await t.test('Multiple File Uploads', async () => {
+    await spec()
+      .post('/multiple')
+      .withFile('file', join(process.cwd(), 'package.json'))
+      .withFile('file', join(process.cwd(), '.eslintrc.json'))
+      .withMultiPartFormData('nonFile', 'Hello World!')
+      .expectStatus(201)
+      .expectBody({ success: true, fileCount: 2 })
+      .toss();
+  });
+
+  await t.test('Any File Upload', async () => {
+    await spec()
+      .post('/any')
+      .withFile('fil', join(process.cwd(), 'package.json'))
+      .withMultiPartFormData('field', 'value')
+      .expectStatus(201)
+      .expectBody({ success: true, fileCount: 1 })
+      .toss();
+  });
+
+  await t.test('File Fields Upload - profile field', async () => {
+    await spec()
+      .post('/fields')
+      .withFile('profile', join(process.cwd(), 'package.json'))
+      .expectStatus(201)
+      .expectBody({ success: true, fileCount: 1 })
+      .toss();
+  });
+
+  await t.test('File Fields Upload - avatar field', async () => {
+    await spec()
+      .post('/fields')
+      .withFile('avatar', join(process.cwd(), 'package.json'))
+      .expectStatus(201)
+      .expectBody({ success: true, fileCount: 1 })
+      .toss();
+  });
+
+  await t.test('File Fields Upload - profile and avatar fields', async () => {
+    await spec()
+      .post('/fields')
+      .withFile('profile', join(process.cwd(), 'package.json'))
+      .withFile('avatar', join(process.cwd(), 'package.json'))
+      .expectStatus(201)
+      .expectBody({ success: true, fileCount: 2 })
+      .toss();
+  });
+
+  await t.test('No File Upload - 201, no file', async () => {
+    await spec()
+      .post('/none')
+      .withMultiPartFormData('no', 'files')
+      .expectStatus(201)
+      .expectBody({ success: true })
+      .toss();
+  });
+
+  await t.test('No File Upload - 400, with file', async () => {
+    await spec()
+      .post('/none')
+      .withFile('file', join(process.cwd(), 'package.json'))
+      .expectStatus(400)
+      .toss();
+  });
+
+  await app.close();
+});

--- a/packages/busboy/test/file-upload-fastify/app/app.controller.ts
+++ b/packages/busboy/test/file-upload-fastify/app/app.controller.ts
@@ -1,0 +1,62 @@
+import {
+  Body,
+  Controller,
+  Post,
+  UploadedFile,
+  UploadedFiles,
+  UseInterceptors,
+} from '@nestjs/common';
+import {
+  AnyFilesInterceptor,
+  FileFieldsInterceptor,
+  FileInterceptor,
+  FilesInterceptor,
+  NoFilesInterceptor,
+  memoryStorage,
+} from '../../../src';
+
+@Controller()
+export class AppController {
+  @Post('single')
+  @UseInterceptors(FileInterceptor('file', { storage: memoryStorage() }))
+  uploadSingleFile(@UploadedFile() file: unknown) {
+    return { success: !!file };
+  }
+
+  @Post('multiple')
+  @UseInterceptors(FilesInterceptor('file', 10, { storage: memoryStorage() }))
+  uploadMultipleFiles(@UploadedFiles() files: unknown[]) {
+    return { success: !!files.length, fileCount: files.length };
+  }
+
+  @Post('any')
+  @UseInterceptors(AnyFilesInterceptor({ storage: memoryStorage() }))
+  uploadAnyFiles(@UploadedFiles() files: unknown[]) {
+    return { success: !!files.length, fileCount: files.length };
+  }
+
+  @Post('fields')
+  @UseInterceptors(
+    FileFieldsInterceptor([{ name: 'profile' }, { name: 'avatar' }], {
+      storage: memoryStorage(),
+    }),
+  )
+  uploadFileFieldsFiles(
+    @UploadedFiles() files: { profile?: unknown[]; avatar?: unknown[] },
+  ) {
+    return {
+      success: !!((files.profile?.length ?? 0) + (files.avatar?.length ?? 0)),
+      fileCount: (files.profile?.length ?? 0) + (files.avatar?.length ?? 0),
+    };
+  }
+
+  @Post('none')
+  @UseInterceptors(NoFilesInterceptor())
+  noFilesAllowed(
+    @Body() body: Record<string, string>,
+    @UploadedFiles() files: unknown[],
+    @UploadedFile() file: unknown,
+  ) {
+    return { success: !files && !file && !!body };
+  }
+}

--- a/packages/busboy/test/file-upload-fastify/app/app.module.ts
+++ b/packages/busboy/test/file-upload-fastify/app/app.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { BusboyModule } from '../../../src';
+import { AppController } from './app.controller';
+
+@Module({
+  imports: [BusboyModule],
+  controllers: [AppController],
+})
+export class AppModule {}

--- a/packages/busboy/test/file-upload-fastify/file-upload-fastify.spec.ts
+++ b/packages/busboy/test/file-upload-fastify/file-upload-fastify.spec.ts
@@ -1,0 +1,93 @@
+import { FastifyAdapter } from '@nestjs/platform-fastify';
+import { Test } from '@nestjs/testing';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { request, spec } from 'pactum';
+import { AppModule } from './app/app.module';
+
+export const uploadFastifyTests = test('Busboy File Upload - Fastify', async (t) => {
+  const modRef = await Test.createTestingModule({
+    imports: [AppModule],
+  }).compile();
+  const app = modRef.createNestApplication(new FastifyAdapter());
+  await app.listen(0);
+  const url = await app.getUrl();
+  request.setBaseUrl(url.replace('[::1]', 'localhost'));
+
+  await t.test('Single File Upload', async () => {
+    await spec()
+      .post('/single')
+      .withFile('file', join(process.cwd(), 'package.json'))
+      .expectStatus(201)
+      .expectBody({ success: true })
+      .toss();
+  });
+
+  await t.test('Multiple File Uploads', async () => {
+    await spec()
+      .post('/multiple')
+      .withFile('file', join(process.cwd(), 'package.json'))
+      .withFile('file', join(process.cwd(), '.eslintrc.json'))
+      .withMultiPartFormData('nonFile', 'Hello World!')
+      .expectStatus(201)
+      .expectBody({ success: true, fileCount: 2 })
+      .toss();
+  });
+
+  await t.test('Any File Upload', async () => {
+    await spec()
+      .post('/any')
+      .withFile('fil', join(process.cwd(), 'package.json'))
+      .withMultiPartFormData('field', 'value')
+      .expectStatus(201)
+      .expectBody({ success: true, fileCount: 1 })
+      .toss();
+  });
+
+  await t.test('File Fields Upload - profile field', async () => {
+    await spec()
+      .post('/fields')
+      .withFile('profile', join(process.cwd(), 'package.json'))
+      .expectStatus(201)
+      .expectBody({ success: true, fileCount: 1 })
+      .toss();
+  });
+
+  await t.test('File Fields Upload - avatar field', async () => {
+    await spec()
+      .post('/fields')
+      .withFile('avatar', join(process.cwd(), 'package.json'))
+      .expectStatus(201)
+      .expectBody({ success: true, fileCount: 1 })
+      .toss();
+  });
+
+  await t.test('File Fields Upload - profile and avatar fields', async () => {
+    await spec()
+      .post('/fields')
+      .withFile('profile', join(process.cwd(), 'package.json'))
+      .withFile('avatar', join(process.cwd(), 'package.json'))
+      .expectStatus(201)
+      .expectBody({ success: true, fileCount: 2 })
+      .toss();
+  });
+
+  await t.test('No File Upload - 201, no file', async () => {
+    await spec()
+      .post('/none')
+      .withMultiPartFormData('no', 'files')
+      .expectStatus(201)
+      .expectBody({ success: true })
+      .toss();
+  });
+
+  await t.test('No File Upload - 400, with file', async () => {
+    await spec()
+      .post('/none')
+      .withFile('file', join(process.cwd(), 'package.json'))
+      .expectStatus(400)
+      .toss();
+  });
+
+  await app.close();
+});

--- a/packages/busboy/test/index.spec.ts
+++ b/packages/busboy/test/index.spec.ts
@@ -1,0 +1,12 @@
+import { uploadExpressTests } from './file-upload-express/file-upload-express.spec';
+import { uploadFastifyTests } from './file-upload-fastify/file-upload-fastify.spec';
+import { multipleImportsTest } from './multiple-imports/multiple-imports.spec';
+import { uploadWithModuleOptionsTest } from './uploads-from-options/upload-from-options.spec';
+
+(async () => {
+  // Run Fastify and Express HTTP tests sequentially to avoid pactum base URL conflicts.
+  // Multiple-imports test has no HTTP calls and can run in parallel.
+  await Promise.all([uploadFastifyTests, multipleImportsTest]);
+  await uploadExpressTests;
+  await uploadWithModuleOptionsTest;
+})();

--- a/packages/busboy/test/multiple-imports/app/app.module.ts
+++ b/packages/busboy/test/multiple-imports/app/app.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { BarModule } from '../bar/bar.module';
+import { FooModule } from '../foo/foo.module';
+
+@Module({
+  imports: [BarModule, FooModule],
+})
+export class AppModule {}

--- a/packages/busboy/test/multiple-imports/bar/bar.module.ts
+++ b/packages/busboy/test/multiple-imports/bar/bar.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { BusboyModule, diskStorage } from '../../../src';
+
+@Module({
+  imports: [
+    BusboyModule.registerAsync({
+      useFactory: () => ({
+        storage: diskStorage({ destination: '/tmp/uploads/' }),
+      }),
+    }),
+  ],
+})
+export class BarModule {}

--- a/packages/busboy/test/multiple-imports/foo/foo.module.ts
+++ b/packages/busboy/test/multiple-imports/foo/foo.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { BusboyModule, memoryStorage } from '../../../src';
+
+@Module({
+  imports: [
+    BusboyModule.registerAsync({
+      useFactory: () => ({
+        storage: memoryStorage(),
+      }),
+    }),
+  ],
+})
+export class FooModule {}

--- a/packages/busboy/test/multiple-imports/multiple-imports.spec.ts
+++ b/packages/busboy/test/multiple-imports/multiple-imports.spec.ts
@@ -1,0 +1,22 @@
+import assert = require('node:assert');
+import { FastifyAdapter } from '@nestjs/platform-fastify';
+import { Test } from '@nestjs/testing';
+import test from 'node:test';
+import { AppModule } from './app/app.module';
+
+export const multipleImportsTest = test('Multiple Import Tests', async (t) => {
+  await t.test('Should boot without conflict', async () => {
+    const modRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    const app = modRef.createNestApplication(new FastifyAdapter());
+    try {
+      await app.listen(0);
+      assert(app !== undefined);
+    } catch {
+      assert(false);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/packages/busboy/test/uploads-from-options/app/app.controller.ts
+++ b/packages/busboy/test/uploads-from-options/app/app.controller.ts
@@ -1,0 +1,11 @@
+import { Controller, Post, UploadedFile, UseInterceptors } from '@nestjs/common';
+import { FileInterceptor } from '../../../src';
+
+@Controller()
+export class AppController {
+  @Post()
+  @UseInterceptors(FileInterceptor('file'))
+  uploadFile(@UploadedFile() file: { filename: string }) {
+    return { filename: file.filename };
+  }
+}

--- a/packages/busboy/test/uploads-from-options/app/app.module.ts
+++ b/packages/busboy/test/uploads-from-options/app/app.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { join } from 'node:path';
+import { BusboyModule } from '../../../src';
+import { AppController } from './app.controller';
+
+@Module({
+  imports: [
+    BusboyModule.register({
+      dest: join(process.cwd(), 'uploads'),
+    }),
+  ],
+  controllers: [AppController],
+})
+export class AppModule {}

--- a/packages/busboy/test/uploads-from-options/upload-from-options.spec.ts
+++ b/packages/busboy/test/uploads-from-options/upload-from-options.spec.ts
@@ -1,0 +1,35 @@
+import { FastifyAdapter } from '@nestjs/platform-fastify';
+import { Test } from '@nestjs/testing';
+import { unlink } from 'fs/promises';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { request, spec } from 'pactum';
+import { AppModule } from './app/app.module';
+
+export const uploadWithModuleOptionsTest = test(
+  'Busboy File Upload with Module Options',
+  async (t) => {
+    const modRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    const app = modRef.createNestApplication(new FastifyAdapter());
+    await app.listen(0);
+    const url = await app.getUrl();
+    request.setBaseUrl(url.replace('[::1]', 'localhost'));
+
+    let filePath = '';
+    await t.test('It should upload the file to the disk', async () => {
+      await spec()
+        .post('/')
+        .withFile('file', join(process.cwd(), 'package.json'))
+        .expectStatus(201)
+        .returns(({ res }) => {
+          filePath = (res.json as any).filename;
+        })
+        .toss();
+    });
+
+    await unlink(join(process.cwd(), 'uploads', filePath));
+    await app.close();
+  },
+);

--- a/packages/busboy/tsconfig.json
+++ b/packages/busboy/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/busboy/tsconfig.lib.json
+++ b/packages/busboy/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"],
+    "target": "es2021"
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts", "test"]
+}

--- a/packages/busboy/tsconfig.spec.json
+++ b/packages/busboy/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": ["jest.config.ts", "**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+}

--- a/packages/fastify-multer/README.md
+++ b/packages/fastify-multer/README.md
@@ -1,3 +1,6 @@
+> **Deprecated**: This package is no longer actively maintained and does not support Fastify v5.
+> Please migrate to [`@nest-lab/busboy`](../busboy/README.md), which supports both Fastify (v4/v5) and Express with the same interceptor API.
+
 # @nest-lab/fastify-multer
 
 Support for File Uploads when using the [`@nestjs/platform-fastify`](https://docs.nestjs.com/techniques/performance) adapter, using the [`fastify-multer`](https://www.npmjs.com/package/fastify-multer) library.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,6 +231,24 @@ importers:
         specifier: ^3.23.8
         version: 3.24.1
 
+  packages/busboy:
+    dependencies:
+      '@fastify/busboy':
+        specifier: ^3.0.0
+        version: 3.2.0
+      '@nestjs/common':
+        specifier: ^9.0.0 || ^10.0.0 || ^11.0.0
+        version: 11.0.5(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/platform-express':
+        specifier: ^9.0.0 || ^10.0.0 || ^11.0.0
+        version: 11.0.5(@nestjs/common@11.0.5(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@11.0.5)
+      '@nestjs/platform-fastify':
+        specifier: ^9.0.0 || ^10.0.0 || ^11.0.0
+        version: 11.0.5(@nestjs/common@11.0.5(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@11.0.5)
+      rxjs:
+        specifier: ^7.0.0
+        version: 7.8.1
+
   packages/fastify-multer:
     dependencies:
       '@nestjs/common':
@@ -1171,6 +1189,9 @@ packages:
     resolution: {integrity: sha512-7PQA7EH43S0CxcOa9OeAnaeA0oQ+e/DHNPZwSQM9CQHW76jle5+OvLdibRp/Aafs9KXbLhxyjOTkRjWUbQEd3Q==}
     engines: {node: '>=14'}
 
+  '@fastify/busboy@3.2.0':
+    resolution: {integrity: sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==}
+
   '@fastify/cors@10.0.2':
     resolution: {integrity: sha512-DGdxOG36sS/tZv1NFiCJGi7wGuXOSPL2CmNX5PbOVKx0C6LuIALRMrqLByHTCcX1Rbl8NJ9IWlJex32bzydvlw==}
 
@@ -1575,48 +1596,56 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-arm64-gnu@19.8.14':
     resolution: {integrity: sha512-2E70qMKOhh7Fp4JGcRbRLvFKq0+ANVdAgSzH47plxOLygIeVAfIXRSuQbCI0EUFa5Sy6hImLaoRSB2GdgKihAw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@19.6.1':
     resolution: {integrity: sha512-3lfazErzsJgO8G2dEcuGmtJoi9fQ3CPvLA+RiE7CKBQ4a/5Zb1o2rqlZ1YTfnfiUcOh4knt7gWcXm16eSKbLoQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-arm64-musl@19.8.14':
     resolution: {integrity: sha512-ltty/PDWqkYgu/6Ye65d7v5nh3D6e0n3SacoKRs2Vtfz5oHYRUkSKizKIhEVfRNuHn3d9j8ve1fdcCN4SDPUBQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@19.6.1':
     resolution: {integrity: sha512-Rt4NkuJZpRyVunRoCC5shaUqPk6wrMH3x55WEb0HBzlKjkItgrFpPInPS4hp9hFsJ8vX2AkBX2qrTWRaLMbOyQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-gnu@19.8.14':
     resolution: {integrity: sha512-JzE3BuO9RCBVdgai18CCze6KUzG0AozE0TtYFxRokfSC05NU3nUhd/o62UsOl7s6Bqt/9nwrW7JC8pNDiCi9OQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@19.6.1':
     resolution: {integrity: sha512-P0RnxCfcgb6t4l+WWVNlTDzqpcM/Du77EfgvNc3Z1mRLQMP4E5TkLt8J/aTTjh2GwtnP95oxQSOYBzg+sJwNPQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-x64-musl@19.8.14':
     resolution: {integrity: sha512-2rPvDOQLb7Wd6YiU88FMBiLtYco0dVXF99IJBRGAWv+WTI7MNr47OyK2ze+JOsbYY1d8aOGUvckUvCCZvZKEfg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@19.6.1':
     resolution: {integrity: sha512-CFaRqK+Sv7Gi7d+WUJqFLV0t4D2ImnO7BoeZWnT6oEfIl94hikCtbu4693Fsu7eg37JMa+4xwdAUvOOq1rFhJg==}
@@ -1711,51 +1740,61 @@ packages:
     resolution: {integrity: sha512-0O8ViX+QcBd3ZmGlcFTnYXZKGbFu09EhgD27tgTdGnkcYXLat4KIsBBQeKLR2xZDCXdIBAlWLkiXE1+rJpCxFw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.31.0':
     resolution: {integrity: sha512-w5IzG0wTVv7B0/SwDnMYmbr2uERQp999q8FMkKG1I+j8hpPX2BYFjWe69xbhbP6J9h2gId/7ogesl9hwblFwwg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.31.0':
     resolution: {integrity: sha512-JyFFshbN5xwy6fulZ8B/8qOqENRmDdEkcIMF0Zz+RsfamEW+Zabl5jAb0IozP/8UKnJ7g2FtZZPEUIAlUSX8cA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.31.0':
     resolution: {integrity: sha512-kpQXQ0UPFeMPmPYksiBL9WS/BDiQEjRGMfklVIsA0Sng347H8W2iexch+IEwaR7OVSKtr2ZFxggt11zVIlZ25g==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.31.0':
     resolution: {integrity: sha512-pMlxLjt60iQTzt9iBb3jZphFIl55a70wexvo8p+vVFK+7ifTRookdoXX3bOsRdmfD+OKnMozKO6XM4zR0sHRrQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.31.0':
     resolution: {integrity: sha512-D7TXT7I/uKEuWiRkEFbed1UUYZwcJDU4vZQdPTcepK7ecPhzKOYk4Er2YR4uHKme4qDeIh6N3XrLfpuM7vzRWQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.31.0':
     resolution: {integrity: sha512-wal2Tc8O5lMBtoePLBYRKj2CImUCJ4UNGJlLwspx7QApYny7K1cUYlzQ/4IGQBLmm+y0RS7dwc3TDO/pmcneTw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.31.0':
     resolution: {integrity: sha512-O1o5EUI0+RRMkK9wiTVpk2tyzXdXefHtRTIjBbmFREmNMy7pFeYXCFGbhKFwISA3UOExlo5GGUuuj3oMKdK6JQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.31.0':
     resolution: {integrity: sha512-zSoHl356vKnNxwOWnLd60ixHNPRBglxpv2g7q0Cd3Pmr561gf0HiAcUBRL3S1vPqRC17Zo2CX/9cPkqTIiai1g==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.31.0':
     resolution: {integrity: sha512-ypB/HMtcSGhKUQNiFwqgdclWNRrAYDH8iMYH4etw/ZlGwiTVxBz2tDrGRrPlfZu6QjXwtd+C3Zib5pFqID97ZA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.31.0':
     resolution: {integrity: sha512-JuhN2xdI/m8Hr+aVO3vspO7OQfUFO6bKLIRTAy0U15vmWjnZDLrEgCZ2s6+scAYaQVpYSh9tZtRijApw9IXyMw==}
@@ -1836,24 +1875,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.5.7':
     resolution: {integrity: sha512-+NDhK+IFTiVK1/o7EXdCeF2hEzCiaRSrb9zD7X2Z7inwWlxAntcSuzZW7Y6BRqGQH89KA91qYgwbnjgTQ22PiQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.5.7':
     resolution: {integrity: sha512-25GXpJmeFxKB+7pbY7YQLhWWjkYlR+kHz5I3j9WRl3Lp4v4UD67OGXwPe+DIcHqcouA1fhLhsgHJWtsaNOMBNg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.5.7':
     resolution: {integrity: sha512-0VN9Y5EAPBESmSPPsCJzplZHV26akC0sIgd3Hc/7S/1GkSMoeuVL+V9vt+F/cCuzr4VidzSkqftdP3qEIsXSpg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.5.7':
     resolution: {integrity: sha512-RtoNnstBwy5VloNCvmvYNApkTmuCe4sNcoYWpmY7C1+bPR+6SOo8im1G6/FpNem8AR5fcZCmXHWQ+EUmRWJyuA==}
@@ -6163,6 +6206,8 @@ snapshots:
   '@fastify/busboy@1.2.1':
     dependencies:
       text-decoding: 1.0.0
+
+  '@fastify/busboy@3.2.0': {}
 
   '@fastify/cors@10.0.2':
     dependencies:

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,6 +16,7 @@
     "strict": true,
     "baseUrl": ".",
     "paths": {
+      "@nest-lab/busboy": ["packages/busboy/src/index.ts"],
       "@nest-lab/fastify-multer": ["packages/fastify-multer/src/index.ts"],
       "@nest-lab/or-guard": ["packages/or-guard/src/index.ts"],
       "@nest-lab/throttler-storage-redis": [


### PR DESCRIPTION
Adds a new `@nest-lab/busboy` package that replaces `@nest-lab/fastify-multer` with a platform-agnostic implementation built directly on `@fastify/busboy`.

The existing package depends on the unmaintained `fastify-multer` library which registers its content-type parser using the string `'multipart'`, a prefix-match that Fastify v5 no longer supports, causing FST_ERR_CTP_INVALID_MEDIA_TYPE (415) on all multipart uploads.

The new package fixes this by:
- Registering a regex-based content-type parser (`/^multipart\/form-data/`) that correctly matches the boundary parameter in Fastify v5
- Detecting the HTTP adapter at boot time (Fastify vs Express) and only registering the parser when on Fastify, Express needs no registration
- Implementing `DiskStorage` and `MemoryStorage` engines directly, removing the dependency on multer entirely
- Providing the identical interceptor API: FileInterceptor, FilesInterceptor, AnyFilesInterceptor, FileFieldsInterceptor, NoFilesInterceptor

Tests cover both Fastify and Express adapters (22 tests total).

`@nest-lab/fastify-multer` README is updated with a deprecation notice.

Closes #59